### PR TITLE
Fixed typo in the italian translation

### DIFF
--- a/Products/Ploneboard/locales/it/LC_MESSAGES/ploneboard.po
+++ b/Products/Ploneboard/locales/it/LC_MESSAGES/ploneboard.po
@@ -322,7 +322,7 @@ msgstr ""
 #. Default: "The maximum allowed attachment size is ${maxsize} kilobytes."
 #: ../skins/ploneboard_templates/add_comment_form.cpt:157
 msgid "help_body_attachments_maxsize"
-msgstr "La dimensione massima perfessa è ${maxsize} kilobytes"
+msgstr "La dimensione massima permessa è ${maxsize} kilobytes"
 
 #. Default: "Select a file to upload as an attachment to this comment."
 #: ../skins/ploneboard_templates/add_comment_form.cpt:151


### PR DESCRIPTION
it's not "perfessa", it's "permessa"
