### PR TITLE
Fixed visual issue with HTML lists when WISIWYG editor is enabled

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,8 @@ Changelog
 3.5 (unreleased)
 ----------------
 
-- Nothing changed yet.
-
+- Fixed visual issue with HTML lists when WISIWYG editor is enabled 
+  [keul]
 
 3.4 (2013-05-11)
 ----------------

--- a/src/Products/Ploneboard/skins/ploneboard_templates/ploneboard.css.dtml
+++ b/src/Products/Ploneboard/skins/ploneboard_templates/ploneboard.css.dtml
@@ -126,6 +126,10 @@
     list-style: none;
 }
 
+.boardConversation .boardCommentContent li {
+    list-style: inherit;
+}
+
 .commentAttachments {
     text-align: left;
     margin: 0 0.5em 0.5em 0.5em;


### PR DESCRIPTION
When TinyMCE is enabled on forum comments you'll get an issue with default CSS styles as _ploneboard.css_ contains a rule that null all styles for `LI` elements.

Don't know why this rule has been added, to prevent any regression we added a new rule that restore normal behavior just only inside `boardCommentContent`
