### PR TITLE
add unmarkCreationFlag call in creation methods

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,9 @@ Changelog
 - Fixed visual issue with HTML lists when WISIWYG editor is enabled 
   [keul]
 
+- Call unmarkCreationFlag method after comment creation, to remove creation flag
+  [cekk]
+
 3.4 (2013-05-11)
 ----------------
 

--- a/src/Products/Ploneboard/content/PloneboardComment.py
+++ b/src/Products/Ploneboard/content/PloneboardComment.py
@@ -166,6 +166,7 @@ class PloneboardComment(BaseBTreeFolder):
             utils.changeOwnershipOf(m, forum.owner_info()['id'], False)
 
         event.notify(ObjectInitializedEvent(m))
+        m.unmarkCreationFlag()
         m.reindexObject()
         conv.reindexObject() # Sets modified
         return m

--- a/src/Products/Ploneboard/content/PloneboardConversation.py
+++ b/src/Products/Ploneboard/content/PloneboardConversation.py
@@ -121,7 +121,7 @@ class PloneboardConversation(BrowserDefaultMixin, BaseBTreeFolder):
 
         event.notify(ObjectInitializedEvent(m))
         m.indexObject()
-
+        m.unmarkCreationFlag()
         self.reindexObject() # Sets modified
         return m
 

--- a/src/Products/Ploneboard/content/PloneboardForum.py
+++ b/src/Products/Ploneboard/content/PloneboardForum.py
@@ -191,7 +191,7 @@ class PloneboardForum(BaseBTreeFolder):
 
             event.notify(ObjectInitializedEvent(m))
             m.reindexObject()
-
+            m.unmarkCreationFlag()
         conv.reindexObject()
         return conv
 


### PR DESCRIPTION
without this call, new comments still have creation flag set until the comment is modified.
