### PR TITLE
IBrowserDefault fix

### DIFF
--- a/Products/Ploneboard/content/PloneboardComment.py
+++ b/Products/Ploneboard/content/PloneboardComment.py
@@ -391,4 +391,9 @@ class PloneboardComment(BaseBTreeFolder):
 
         return self.restrictedTraverse('@@delete_view')()
 
+
+    # so that the implementation of IBrowserDefault for older versions of Plone
+    def getLayout (self):
+        return "singlecomment_view"
+
 registerType(PloneboardComment, PROJECTNAME)


### PR DESCRIPTION
on older version of plone (in this case Plone 4.1) the comment content type declares it implementes IBrowserDefault, however, getLayout() is not implemented and returns a bad value (from the parent) which causes an attribute error such as the folloing from TinyMCE 1.3.5

```
    template = None
    if IBrowserDefault.providedBy(context):
        template = context.unrestrictedTraverse(context.getLayout())
```

This results in a attribute error in the unrestrictedTraverse:
    **\* AttributeError: conversation_browserview

this update returns a sain value for getLayout() in newer versions of Plone the comment doesn't seem to inherit this IBrowserDefault interface so this is more of a backwards compatibility fix.
